### PR TITLE
Add API calls and test

### DIFF
--- a/assets/js/backend.js
+++ b/assets/js/backend.js
@@ -1,0 +1,95 @@
+var aqiApiKey = 'f0e219ddc1e9e02d7eb8f05a9898db976526d09a';
+var aqiApiUrl = 'https://api.waqi.info/feed';
+
+var countryApiUrl = 'https://countriesnow.space/api/v0.1/countries/population/cities';
+
+var currencyApiUrl = 'https://countriesnow.space/api/v0.1/countries/currency';
+
+var currencyExchangeApiUrl = 'https://api.api-ninjas.com/v1/convertcurrency';
+var currencyExchangeApiKey = 'zoACBAtFNJtKJAL8Nl7DlA==nqcwIFNykYOqSb4K';
+
+var city = 'Shanghai';
+var localCurrency = 'USD';
+
+
+// Helper functions
+function getCountry(city){
+    return fetch(countryApiUrl, {
+        method: "POST",
+        headers: {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({"city":city})
+    })
+    .then(response => {
+        return response.json();
+    })
+    .then(json => {
+        return json.data.country;
+    });
+}
+
+function getCurrency(country){
+    return fetch(currencyApiUrl, {
+        method: "POST",
+        headers: {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({"country":country})
+    })
+    .then(function(response){
+        return response.json();
+    })
+    .then(function(json){
+        return json.data.currency;
+    });
+}
+
+function getExchangeRate(localCurrency, foreignCurrency){
+    return fetch(`${currencyExchangeApiUrl}?have=${localCurrency}&want=${foreignCurrency}&amount=1`, {
+        headers: {
+            'X-Api-Key': currencyExchangeApiKey,
+        }
+    })
+    .then(function(response){
+        return response.json();
+    });
+}
+
+
+
+// API calls
+function getAQI(city, onSuccess, onFailure){
+    var url = `${aqiApiUrl}/${city}/?token=${aqiApiKey}`;
+    fetch(url)
+    .then(function (response) {
+        return response.json();
+    })
+    .then(json => {return json.data.aqi;})
+    .then(onSuccess)
+    .catch(onFailure);
+}
+
+function getCurrencyExchangeRate(city, onSuccess, onFailure){
+    getCountry(city)
+    .then(country=>{return getCurrency(country)})
+    .then(cur => {return getExchangeRate(localCurrency, cur)})
+    .then(onSuccess)
+    .catch(onFailure);  
+}
+
+
+var aqiElement = document.getElementById('aqi');
+var exchangeElement = document.getElementById('exchange');
+
+getAQI(city, aqi => {
+        aqiElement.textContent = `AQI in ${city} is ${aqi}`;
+    },
+    ()=>{console.log('fetch call failed!')});
+
+getCurrencyExchangeRate(city, json=>{
+        exchangeElement.textContent = `${json.old_amount} ${json.old_currency} = ${json.new_amount} ${json.new_currency}`;
+    }, 
+    ()=>{console.log('fetch call failed!')});

--- a/test/test.html
+++ b/test/test.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Test</title>
+    
+</head>
+<body>
+    <div id="aqi" style="border:2px solid darkred; margin:5px;">
+        AQI
+    </div>
+    <div id="exchange" style="border:2px solid darkgreen; margin:5px;">
+        Currency Exchange
+    </div>
+    <script src="../assets/js/backend.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Added API calls and a simple test.html page just to load the script

### Usage
Lines 64 and 75 contain the definition of the API call functions, both work the same.
Since the calls are async, we need to pass callbacks functions for both successful and failed results.

Lines 87 and 92 are examples of how to call the function. For example, when calling `getAQI`,
- the first parameter is `city`: the city we want to obtain info from,
- the second parameter is ```aqi => {aqiElement.textContent = `AQI in ${city} is ${aqi}`;}```
this function will be called when the request (or chain of requests) is completed successfully and will set a div content to the result of the request,
- the third parameter is ```()=>{console.log('fetch call failed!')});```
this function will simply console log a failure message.